### PR TITLE
fix(deps): pin mcp to stable v1.x and fix import path

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ dependencies = [
     "beautifulsoup4>=4.13.4",
     "httpx>=0.28.1",
     "humanize>=4.11.0",
-    "mcp @ git+https://github.com/modelcontextprotocol/python-sdk.git@main",
+    "mcp>=1.25,<2",
     "platformdirs>=4.0.0",
     "rich>=13.10.0",
     "structlog>=25.4.0",

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ setup(
         "aiofiles>=24.1.0",
         "beautifulsoup4>=4.13.4",
         "httpx>=0.28.1",
-        "mcp @ git+https://github.com/modelcontextprotocol/python-sdk.git@main",
+        "mcp>=1.25,<2",
         "platformdirs>=4.0.0",
         "structlog>=25.4.0",
     ],


### PR DESCRIPTION
- Restrict mcp dependency to >=1.25,<2 in setup.py and pyproject.toml to avoid unstable v2.0 development versions.
- Ensure compatibility by using the internal mcp.server.fastmcp import path.
- Sync versioning across build configuration files.

Partial patch for #9 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated mcp package dependency from direct git source to a version-constrained release (>=1.25,<2) in project configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->